### PR TITLE
Support for message.key of type bytes

### DIFF
--- a/flask_and_kafka/consumer.py
+++ b/flask_and_kafka/consumer.py
@@ -117,14 +117,17 @@ class FlaskKafkaConsumer:
                     else:
                         raise KafkaException(msg.error())
 
-                for topic, func in topics:
-                    if msg.topic() == topic:
-                        self.consumer_logger.info('', extra={"consumer_message": msg})
-                        func(msg)
-                        break
+                self._call_message_handlers(msg, topics)
                     
                 consumer.commit(asynchronous=True) # commit offsets after processing the batch of messages
         except KafkaException as e:
             print('Exception in Kafka consumer thread: %s', e)            
         finally:
             consumer.close() # close the consumer when the thread is terminated
+
+    def _call_message_handlers(self, msg, topics):
+        for topic, func in topics:
+            if msg.topic() == topic:
+                self.consumer_logger.info('', extra={"consumer_message": msg})
+                func(msg)
+                break

--- a/flask_and_kafka/formatters.py
+++ b/flask_and_kafka/formatters.py
@@ -10,8 +10,8 @@ class ConsumerFormatter(logging.Formatter):
             "time": record.asctime, 
             "threadName": record.threadName,
             'topic': record.consumer_message.topic(),
-            'key': record.consumer_message.key(),
-            'value': str(record.consumer_message.value(), 'utf-8'),
+            'key': str(record.consumer_message.key()),
+            'value': str(record.consumer_message.value()),
             'partition': record.consumer_message.partition(),
             'offset': record.consumer_message.offset(),
             'error': record.consumer_message.error()

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -53,7 +53,12 @@ class TestFlaskKafkaConsumer(unittest.TestCase):
             nonlocal handler_was_called
             handler_was_called = True
             self.assertEqual(msg.topic(), self.topic)
-
+            self.assertEqual(msg.partition(), 0)
+            self.assertEqual(msg.offset(), 1)
+            self.assertEqual(msg.value(), b'test value')
+            self.assertEqual(msg.key(), b'key value')
+            self.assertEqual(msg.error(), None)
+            self.assertEqual(msg.headers(), None)
 
         msg = mock.Mock(confluent_kafka.Message)
         msg.topic.return_value = self.topic
@@ -65,7 +70,6 @@ class TestFlaskKafkaConsumer(unittest.TestCase):
         msg.headers.return_value = None
 
         self.consumer._call_message_handlers(msg, self.consumer.topics[self.group_id])
-
         self.assertTrue(handler_was_called, "handler was not called")
 
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -18,14 +18,9 @@ class TestFlaskKafkaConsumer(unittest.TestCase):
         self.consumer = FlaskKafkaConsumer(self.app)
 
     def test_handle_message_decorator(self):
-        topic = 'test-topic'
-        group_id = 'test-group'
-        num_consumers = 1
-
         @self.consumer.handle_message(topic=self.topic, group_id=self.group_id, num_consumers=self.num_consumers)
         def test_handler(msg):
-            print(f"Received message: {msg.value().decode('utf-8')}")
-
+            pass
         self.assertEqual(len(self.consumer.consumers), self.num_consumers)
         self.assertEqual(len(self.consumer.topics[self.group_id]), 1)
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -52,13 +52,15 @@ class TestFlaskKafkaConsumer(unittest.TestCase):
         def test_handler(msg):
             nonlocal handler_was_called
             handler_was_called = True
+            self.assertEqual(msg.topic(), self.topic)
+
 
         msg = mock.Mock(confluent_kafka.Message)
         msg.topic.return_value = self.topic
         msg.partition.return_value = 0
-        msg.offset.return_value = 0
+        msg.offset.return_value = 1
         msg.value.return_value = b"test value"
-        msg.key.return_value = b"key key"  # <- Key can be a byte string
+        msg.key.return_value = b"key value"  # can be bytes or string.
         msg.error.return_value = None
         msg.headers.return_value = None
 

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -21,19 +21,19 @@ class TestFlaskKafkaProducer(unittest.TestCase):
         with patch.object(self.producer, 'producer', self.mock_producer):
             self.producer.send_message(self.topic, self.message)
 
-        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message)
+        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message, key=None)
         self.assertEqual(self.mock_producer.produce.call_count, 1)
 
     def test_send_message_flush(self):
         with patch.object(self.producer, 'producer', self.mock_producer):
             self.producer.send_message(self.topic, self.message, flush=True)
-        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message)
+        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message, key=None)
         self.mock_producer.flush.assert_called_once_with()
 
     def test_send_message_poll(self):
         with patch.object(self.producer, 'producer', self.mock_producer):
             self.producer.send_message(self.topic, self.message, poll=True)
-        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message)
+        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message, key=None)
         self.mock_producer.poll.assert_called_once_with(1)
 
     def test_close(self):


### PR DESCRIPTION
Hi, 

Thank you for your work on kafka_and_flask. 

This PR fixes an issue I found an issue when confluent-kafka returns Message objects with the "key" parameter set with the type bytes. 

According to confluent_kafka.cimpl.Message, both key and value can be str, bytes or None.

When key is bytes, it triggers an exception in `flask_and_kafka.formatters.ConsumerFormatter.format`, because variables of type bytes cannot be serialized to a JSON. 

It also adds a few related tests and cleans the existing tests a bit, since they didn't run cleanly out of the box for me. 

I hope you will consider this PR for inclusion in upstream. 

Thank you!