### PR TITLE
Publish messages with Kafka headers set

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,12 @@ Note:
 + If `flush` is True, any outstanding messages in the producer's buffer will be sent immediately after the current message is sent.
 + If `poll` is True, the producer will wait for any outstanding messages to be sent before returning, up to the specified `poll_timeout`.
 + The `poll` argument is only relevant if `flush` is False, since the producer always waits for outstanding messages to be sent before flushing. 
+
+### Configuring logging infrastructure
+
+The environment variables `KAFKA_PRODUCER_LOG_PATH` and `KAFKA_CONSUMER_LOG_PATH` set the file where the log records 
+are written. By default these are `logs/kafka_producer.log` and `logs/kafka_consumer.log`.
+
+If you have your own logging configuration you can set `KAFKA_LOG_EXTERNALLY_CONFIGURED=1` and the 
+applications logging configuration will be respected. The python logger names are `producer_logger` and 
+`consumer_logger`.  

--- a/flask_and_kafka/consumer.py
+++ b/flask_and_kafka/consumer.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 import threading
 from typing import List
 from typing import Tuple
@@ -25,7 +26,12 @@ class FlaskKafkaConsumer:
     def init_app(self, app: Flask) -> None:
         self._app = app
         app.extensions['kafka_consumer'] = self
-        self.consumer_logger = consumer_logger(name='consumer_logger', file=app.config.get('KAFKA_CONSUMER_LOG_PATH', 'logs/kafka_consumer.log'))
+        
+        logger_name = 'consumer_logger'
+        if app.config.get('KAFKA_LOG_EXTERNALLY_CONFIGURED', ''):
+            self.consumer_logger = logging.getLogger(logger_name)
+        else:
+            self.consumer_logger = consumer_logger(name=logger_name, file=app.config.get('KAFKA_CONSUMER_LOG_PATH', 'logs/kafka_consumer.log'))
 
     def register_consumers(self, consumers: List[str]) -> None:
         for consumer_name in consumers:

--- a/flask_and_kafka/producer.py
+++ b/flask_and_kafka/producer.py
@@ -17,7 +17,8 @@ class FlaskKafkaProducer:
         self.producer = Producer(app.config['KAFKA_PRODUCER_CONFIGS'])
         self.producer_logger = producer_logger(name='producer_logger', file=app.config.get('KAFKA_PRODUCER_LOG_PATH', 'logs/kafka_producer.log'))
 
-    def send_message(self, topic: str, value: any, key: str = None, flush: bool = False, poll: bool = True, poll_timeout = 1, **kwargs) -> None:
+    def send_message(self, topic: str, value: any, key: str = None, headers = None,
+                     flush: bool = False, poll: bool = True, poll_timeout = 1, **kwargs) -> None:
         """ 
         Send a message to the specified Kafka topic with the given key and value.
 
@@ -25,6 +26,7 @@ class FlaskKafkaProducer:
             topic (str): The Kafka topic to send the message to.
             value (any): The message value to send.
             key (str, optional): The message key to use (default: None).
+            headers (dict[str, Union[str, None]], optional): Message headers to include (default: None).
             flush (bool, optional): Whether to flush the producer's message buffer immediately after sending the message (default: False).
             poll (bool, optional): Whether to wait for any outstanding messages to be sent before returning (default: True).
             poll_timeout (float, optional): The maximum amount of time to wait for outstanding messages to be sent, in seconds (default: 1).
@@ -45,7 +47,7 @@ class FlaskKafkaProducer:
         
         error = None
         try:
-            self.producer.produce(topic=topic, key=key, value=value, **kwargs)
+            self.producer.produce(topic=topic, key=key, value=value, headers=headers, **kwargs)
         except KafkaError as e:
             error = f'Error producing message to topic {topic}: {e}'
         else:
@@ -59,6 +61,7 @@ class FlaskKafkaProducer:
                     'topic': topic,
                     'key': key,
                     'value': value,
+                    'headers': headers,
                     'flush': flush,
                     'poll': poll,
                     'poll_timeout': poll_timeout,

--- a/flask_and_kafka/producer.py
+++ b/flask_and_kafka/producer.py
@@ -1,3 +1,5 @@
+import logging
+
 from flask import Flask
 from confluent_kafka import Producer
 from confluent_kafka import KafkaError
@@ -15,7 +17,12 @@ class FlaskKafkaProducer:
     def init_app(self, app: Flask) -> None:
         app.extensions['kafka_producer'] = self
         self.producer = Producer(app.config['KAFKA_PRODUCER_CONFIGS'])
-        self.producer_logger = producer_logger(name='producer_logger', file=app.config.get('KAFKA_PRODUCER_LOG_PATH', 'logs/kafka_producer.log'))
+
+        logger_name = 'producer_logger'
+        if app.config.get('KAFKA_LOG_EXTERNALLY_CONFIGURED', ''):
+            self.producer_logger = logging.getLogger(logger_name)
+        else:
+            self.producer_logger = producer_logger(name=logger_name, file=app.config.get('KAFKA_PRODUCER_LOG_PATH', 'logs/kafka_producer.log'))
 
     def send_message(self, topic: str, value: any, key: str = None, headers = None,
                      flush: bool = False, poll: bool = True, poll_timeout = 1, **kwargs) -> None:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -57,8 +57,8 @@ class TestFlaskKafkaConsumer(unittest.TestCase):
             self.assertEqual(msg.offset(), 1)
             self.assertEqual(msg.value(), b'test value')
             self.assertEqual(msg.key(), b'key value')
-            self.assertEqual(msg.error(), None)
-            self.assertEqual(msg.headers(), None)
+            self.assertEqual(msg.headers(), {"first": "one", "second": 2})
+            self.assertIsNone(msg.error())
 
         msg = mock.Mock(confluent_kafka.Message)
         msg.topic.return_value = self.topic
@@ -66,8 +66,8 @@ class TestFlaskKafkaConsumer(unittest.TestCase):
         msg.offset.return_value = 1
         msg.value.return_value = b"test value"
         msg.key.return_value = b"key value"  # can be bytes or string.
+        msg.headers.return_value = {"first": "one", "second": 2}
         msg.error.return_value = None
-        msg.headers.return_value = None
 
         self.consumer._call_message_handlers(msg, self.consumer.topics[self.group_id])
         self.assertTrue(handler_was_called, "handler was not called")

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -22,7 +22,16 @@ class TestFlaskKafkaProducer(unittest.TestCase):
         with patch.object(self.producer, 'producer', self.mock_producer):
             self.producer.send_message(self.topic, self.message)
 
-        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message, key=None)
+        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message, key=None, headers=None)
+        self.assertEqual(self.mock_producer.produce.call_count, 1)
+
+
+    def test_send_message_headers(self):
+        headers = {'header1': 'value1', 'header2': 'value2'}
+        with patch.object(self.producer, 'producer', self.mock_producer):
+            self.producer.send_message(self.topic, self.message, headers=headers)
+
+        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message, key=None, headers=headers)
         self.assertEqual(self.mock_producer.produce.call_count, 1)
 
     def test_send_message_byte_values(self):
@@ -33,7 +42,7 @@ class TestFlaskKafkaProducer(unittest.TestCase):
             with patch.object(formatters, 'json', mock_json):
                 self.producer.send_message(self.topic, message_bytes, key=key_bytes)
 
-        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=message_bytes, key=key_bytes)
+        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=message_bytes, key=key_bytes, headers=None)
         self.assertEqual(self.mock_producer.produce.call_count, 1)
 
         self.assertEqual("b'key'", mock_json.dumps.call_args[0][0]['key'])
@@ -42,13 +51,13 @@ class TestFlaskKafkaProducer(unittest.TestCase):
     def test_send_message_flush(self):
         with patch.object(self.producer, 'producer', self.mock_producer):
             self.producer.send_message(self.topic, self.message, flush=True)
-        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message, key=None)
+        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message, key=None, headers=None)
         self.mock_producer.flush.assert_called_once_with()
 
     def test_send_message_poll(self):
         with patch.object(self.producer, 'producer', self.mock_producer):
             self.producer.send_message(self.topic, self.message, poll=True)
-        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message, key=None)
+        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message, key=None, headers=None)
         self.mock_producer.poll.assert_called_once_with(1)
 
     def test_close(self):

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -1,8 +1,10 @@
+import json
+import tempfile
 import unittest
 from unittest.mock import  patch, Mock
 from flask import Flask
 from flask_and_kafka import FlaskKafkaProducer
-from flask_and_kafka import formatters
+from flask_and_kafka.log import producer_logger
 
 
 class TestFlaskKafkaProducer(unittest.TestCase):
@@ -25,28 +27,36 @@ class TestFlaskKafkaProducer(unittest.TestCase):
         self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message, key=None, headers=None)
         self.assertEqual(self.mock_producer.produce.call_count, 1)
 
-
     def test_send_message_headers(self):
         headers = {'header1': 'value1', 'header2': 'value2'}
+        log_file = tempfile.NamedTemporaryFile()
+
         with patch.object(self.producer, 'producer', self.mock_producer):
+            self.producer.producer_logger = producer_logger(name="test", file=log_file.name)
             self.producer.send_message(self.topic, self.message, headers=headers)
 
         self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=self.message, key=None, headers=headers)
         self.assertEqual(self.mock_producer.produce.call_count, 1)
 
+        log_records = [json.loads(line) for line in log_file.readlines()]
+        self.assertEqual(log_records[0]['headers'], headers)
+
     def test_send_message_byte_values(self):
-        mock_json = Mock()
         message_bytes = b'Hello, Bytes!'
         key_bytes = b'key'
-        with patch.object(self.producer, 'producer', self.mock_producer):
-            with patch.object(formatters, 'json', mock_json):
-                self.producer.send_message(self.topic, message_bytes, key=key_bytes)
+        log_file = tempfile.NamedTemporaryFile()
 
-        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=message_bytes, key=key_bytes, headers=None)
+        self.producer.producer_logger = producer_logger(name="test_producer", file=log_file.name)
+        with patch.object(self.producer, 'producer', self.mock_producer):
+            self.producer.send_message(self.topic, message_bytes, key=key_bytes)
+
+        self.mock_producer.produce.assert_called_once_with(topic=self.topic, value=message_bytes, key=key_bytes,
+                                                           headers=None)
         self.assertEqual(self.mock_producer.produce.call_count, 1)
 
-        self.assertEqual("b'key'", mock_json.dumps.call_args[0][0]['key'])
-        self.assertEqual("b'Hello, Bytes!'", mock_json.dumps.call_args[0][0]['value'])
+        log_records = [json.loads(line) for line in log_file.readlines()]
+        self.assertEqual(log_records[0]['key'], "b'key'")
+        self.assertEqual(log_records[0]['value'], "b'Hello, Bytes!'")
 
     def test_send_message_flush(self):
         with patch.object(self.producer, 'producer', self.mock_producer):


### PR DESCRIPTION
A change for your consideration for upstream integration. 

Allows a publisher to set headers values in Kafka messages. In the consumer message handlers they are available standard in the message data coming from kafka. 

Additionally: Allows disabling of the library's logging configuration for integration with projects that have their own logging setup. 
